### PR TITLE
Add waiting time

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,13 @@ By default, there will be a 2 second sleep time between each check. You can modi
     environment:
       - SLEEP_LENGTH: 0.5
 ```
+
+To add a limit to the waiting time in seconds, define `WAIT_FOR` environment variable:
+
+```yaml
+  start_dependencies:
+    image: dadarek/wait-for-dependencies
+    environment:
+      - SLEEP_LENGTH: 0.5
+      - WAIT_FOR: 10
+```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,10 +1,25 @@
 #!/bin/sh
-
 : ${SLEEP_LENGTH:=2}
+
+SLEPT=0
+
+keep_waiting(){
+  if [ -n "$WAIT_FOR" ]; then
+    if [ "$WAIT_FOR" -gt "$SLEPT" ]; then
+      echo "waiting for ${WAIT_FOR}s current ${SLEPT}s"
+      return 0
+    else
+      echo "Exceed waiting limit $SLEPT"
+      return 1
+    fi
+  else
+    return 0
+  fi
+}
 
 wait_for() {
   echo Waiting for $1 to listen on $2...
-  while ! nc -z $1 $2; do echo sleeping; sleep $SLEEP_LENGTH; done
+  while keep_waiting && ! nc -z $1 $2; do echo sleeping; sleep $SLEEP_LENGTH; SLEPT=$((SLEEP_LENGTH+SLEPT)); done
 }
 
 for var in "$@"


### PR DESCRIPTION
Allow user to set limit the waiting time for a dependent container. 

The reason for including this is to avoid infinite wait when one of the dependent container is in a crashing loop or not starting.