### PR TITLE
Update README to correct environment config

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ By default, there will be a 2 second sleep time between each check. You can modi
   start_dependencies:
     image: dadarek/wait-for-dependencies
     environment:
-      - SLEEP_LENGTH: 0.5
+      - SLEEP_LENGTH=0.5
 ```
 
 By default, there will be a 300 seconds timeout before cancelling the wait_for. You can modify this by setting the `TIMEOUT_LENGTH` environment variable:
@@ -62,6 +62,6 @@ By default, there will be a 300 seconds timeout before cancelling the wait_for. 
   start_dependencies:
     image: dadarek/wait-for-dependencies
     environment:
-      - SLEEP_LENGTH: 1
-      - TIMEOUT_LENGTH: 60
+      - SLEEP_LENGTH=1
+      - TIMEOUT_LENGTH=60
 ```


### PR DESCRIPTION
original format: "SLEEP_LENGTH: 1" doesn't work, should be "SLEEP_LENGTH=1"